### PR TITLE
Add low-level support for uuid_bridge and uuid_park

### DIFF
--- a/src/NEventSocket/ApplicationExtensions.cs
+++ b/src/NEventSocket/ApplicationExtensions.cs
@@ -124,6 +124,11 @@ namespace NEventSocket
             return eventSocket.ExecuteApplication(uuid, "spandsp_stop_dtmf");
         }
 
+        public static async Task Bridge(this EventSocket eventSocket, string uuid1, string uuid2)
+        {
+            await eventSocket.SendApi("uuid_bridge {0} {1}".Fmt(uuid1, uuid2));
+        }
+
         private static void LogFailedApplicationResult(EventSocket eventSocket, ApplicationResult result)
         {
             if (result.ChannelData != null)

--- a/src/NEventSocket/ApplicationExtensions.cs
+++ b/src/NEventSocket/ApplicationExtensions.cs
@@ -129,6 +129,11 @@ namespace NEventSocket
             await eventSocket.SendApi("uuid_bridge {0} {1}".Fmt(uuid1, uuid2));
         }
 
+        public static async Task Park(this EventSocket eventSocket, string uuid)
+        {
+            await eventSocket.SendApi("uuid_park {0}".Fmt(uuid));
+        }
+
         private static void LogFailedApplicationResult(EventSocket eventSocket, ApplicationResult result)
         {
             if (result.ChannelData != null)

--- a/src/NEventSocket/ApplicationExtensions.cs
+++ b/src/NEventSocket/ApplicationExtensions.cs
@@ -124,14 +124,14 @@ namespace NEventSocket
             return eventSocket.ExecuteApplication(uuid, "spandsp_stop_dtmf");
         }
 
-        public static async Task Bridge(this EventSocket eventSocket, string uuid1, string uuid2)
+        public static async Task<ApiResponse> Bridge(this EventSocket eventSocket, string uuid1, string uuid2)
         {
-            await eventSocket.SendApi("uuid_bridge {0} {1}".Fmt(uuid1, uuid2));
+            return await eventSocket.SendApi("uuid_bridge {0} {1}".Fmt(uuid1, uuid2));
         }
 
-        public static async Task Park(this EventSocket eventSocket, string uuid)
+        public static async Task<ApiResponse> Park(this EventSocket eventSocket, string uuid)
         {
-            await eventSocket.SendApi("uuid_park {0}".Fmt(uuid));
+            return await eventSocket.SendApi("uuid_park {0}".Fmt(uuid));
         }
 
         private static void LogFailedApplicationResult(EventSocket eventSocket, ApplicationResult result)


### PR DESCRIPTION
Because I needed a bit more control about the bridging process than the bridge application offered me, I found `uuid_bridge` and `uuid_park` very useful.  This PR supports them.

Note that the `Park()` method in the Channel API did not work for me, because it was blocking for the whole time the channel was parked and also did not seem to break out of a bridge the call was previously in. 
