### PR TITLE
Add channel state None (CS_NONE)

### DIFF
--- a/src/NEventSocket/FreeSwitch/ChannelState.cs
+++ b/src/NEventSocket/FreeSwitch/ChannelState.cs
@@ -38,7 +38,9 @@ namespace NEventSocket.FreeSwitch
 
         Destroy,
 
-        Reporting
+        Reporting,
+
+        None
 #pragma warning restore 1591
     }
 }


### PR DESCRIPTION
There is one more ChannelState, which is `CS_NONE`. I received that on an `bgapi outgoing` when my client was subscribed to all events. The event in question had `AnswerState` set to `Ringing`. 

I am actually not sure what `None` means, but it should definitely be supported by NEventSocket. You can find traces of `CS_NONE` in the API documentation http://docs.freeswitch.org/switch__types_8h.html but not in the official documentation AFAIK.
